### PR TITLE
Upgrade Loom to 1.10.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-    id 'fabric-loom' version '1.7-SNAPSHOT'
+    // Updated to support Minecraft 1.21.7
+    id 'fabric-loom' version '1.10.1'
     id 'maven-publish'
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- use Fabric Loom `1.10.1` for Minecraft 1.21.7
- update Gradle wrapper to 8.12

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_686425b05104833185fd538de412d73f